### PR TITLE
ReverseSortedSet: typing & Map based

### DIFF
--- a/src/aberdeen.ts
+++ b/src/aberdeen.ts
@@ -1,4 +1,5 @@
 import { ReverseSortedSet } from "./helpers/reverseSortedSet.js";
+import type { ReverseSortedSetPointer } from "./helpers/reverseSortedSet.js";
 
 /*
  * QueueRunner
@@ -9,6 +10,8 @@ import { ReverseSortedSet } from "./helpers/reverseSortedSet.js";
 interface QueueRunner {
 	prio: number; // Higher values have higher priority
 	queueRun(): void;
+
+	[ptr: ReverseSortedSetPointer]: QueueRunner;
 }
 
 let sortedQueue: ReverseSortedSet<QueueRunner> | undefined; // When set, a runQueue is scheduled or currently running.
@@ -167,6 +170,8 @@ abstract class Scope implements QueueRunner {
 	// handled before their children (as they should), and observes are executed in the
 	// order of the source code.
 	prio: number = --lastPrio;
+
+	[ptr: ReverseSortedSetPointer]: this;
 
 	abstract onChange(index: any, newData: DatumType, oldData: DatumType): void;
 	abstract queueRun(): void;

--- a/src/aberdeen.ts
+++ b/src/aberdeen.ts
@@ -14,7 +14,7 @@ interface QueueRunner {
 	[ptr: ReverseSortedSetPointer]: QueueRunner;
 }
 
-let sortedQueue: ReverseSortedSet<QueueRunner> | undefined; // When set, a runQueue is scheduled or currently running.
+let sortedQueue: ReverseSortedSet<QueueRunner, "prio"> | undefined; // When set, a runQueue is scheduled or currently running.
 let runQueueDepth = 0; // Incremented when a queue event causes another queue event to be added. Reset when queue is empty. Throw when >= 42 to break (infinite) recursion.
 let topRedrawScope: Scope | undefined; // The scope that triggered the current redraw. Elements drawn at this scope level may trigger 'create' animations.
 
@@ -31,7 +31,7 @@ export type DatumType =
 
 function queue(runner: QueueRunner) {
 	if (!sortedQueue) {
-		sortedQueue = new ReverseSortedSet<QueueRunner>("prio");
+		sortedQueue = new ReverseSortedSet<QueueRunner, "prio">("prio");
 		setTimeout(runQueue, 0);
 	} else if (!(runQueueDepth & 1)) {
 		runQueueDepth++; // Make it uneven
@@ -447,7 +447,9 @@ class SetArgScope extends ChainedScope {
 	}
 }
 
-let immediateQueue: ReverseSortedSet<Scope> = new ReverseSortedSet("prio");
+let immediateQueue: ReverseSortedSet<Scope, "prio"> = new ReverseSortedSet(
+	"prio",
+);
 
 class ImmediateScope extends RegularScope {
 	onChange(index: any, newData: DatumType, oldData: DatumType) {
@@ -496,9 +498,8 @@ class OnEachScope extends Scope {
 	byIndex: Map<any, OnEachItemScope> = new Map();
 
 	/** The reverse-ordered list of item scopes, not including those for which makeSortKey returned undefined. */
-	sortedSet: ReverseSortedSet<OnEachItemScope> = new ReverseSortedSet(
-		"sortKey",
-	);
+	sortedSet: ReverseSortedSet<OnEachItemScope, "sortKey"> =
+		new ReverseSortedSet("sortKey");
 
 	/** Indexes that have been created/removed and need to be handled in the next `queueRun`. */
 	changedIndexes: Set<any> = new Set();

--- a/src/helpers/reverseSortedSet.ts
+++ b/src/helpers/reverseSortedSet.ts
@@ -1,4 +1,9 @@
-type Item<T> = T & { [idx: symbol]: Item<T> };
+// Meta-data is saved in-place on ReverseSorted items.
+// - Items in the set should indicate they support {[ptr: ReverseSortedSetPointer]: SELF}
+export type ReverseSortedSetPointer = symbol;
+
+// ReverseSortedSet saves the skip links for all required levels on the object itself
+type SkipItem<T> = { [idx: ReverseSortedSetPointer]: T };
 
 /**
  * A set-like collection of objects that can do iteration sorted by a specified index property.
@@ -8,11 +13,11 @@ type Item<T> = T & { [idx: symbol]: Item<T> };
  * It's implemented as a skiplist, maintaining all meta-data as part of the objects that it
  * is tracking, for performance.
  */
-export class ReverseSortedSet<T extends object> {
+export class ReverseSortedSet<T extends SkipItem<T>> {
 	// A fake item, that is not actually T, but *does* contain symbols pointing at the first item for each level.
-	private tail: Item<T>;
+	private tail: SkipItem<T>;
 	// As every SkipList instance has its own symbols, an object can be included in more than one SkipList.
-	private symbols: symbol[];
+	private symbols: ReverseSortedSetPointer[];
 
 	/**
 	 * Create an empty SortedSet.
@@ -21,8 +26,8 @@ export class ReverseSortedSet<T extends object> {
 	 * using `<` will be done on this property, so it should probably be a number or a string (or something that
 	 * has a useful toString-conversion).
 	 */
-	constructor(private keyProp: keyof T) {
-		this.tail = {} as Item<T>;
+	constructor(private keyProp: string) {
+		this.tail = {} as SkipItem<T>;
 		this.symbols = [Symbol(0)];
 	}
 
@@ -52,17 +57,18 @@ export class ReverseSortedSet<T extends object> {
 			this.symbols.push(Symbol(l));
 
 		const keyProp = this.keyProp;
-		const key = item[keyProp];
+		const key = (item as any)[keyProp];
 
-		let prev: Item<T> | undefined;
-		let current: Item<T> = this.tail;
+		// prev is always a complete T, current might be tail only contain pointers
+		let prev: T | undefined;
+		let current: SkipItem<T> = this.tail;
 		for (let l = this.symbols.length - 1; l >= 0; l--) {
 			const symbol = this.symbols[l];
-			while ((prev = current[symbol] as Item<T>) && prev[keyProp] > key)
+			while ((prev = current[symbol]) && (prev as any)[keyProp] > key)
 				current = prev;
 			if (l < level) {
-				(item as any)[symbol] = current[symbol];
-				(current as any)[symbol] = item;
+				(item as SkipItem<T>)[symbol] = current[symbol];
+				current[symbol] = item;
 			}
 		}
 
@@ -106,16 +112,18 @@ export class ReverseSortedSet<T extends object> {
 	 *
 	 * Time complexity: O(log n)
 	 */
-	get(indexValue: string | number): T | undefined {
+	get(indexValue: any): T | undefined {
 		const keyProp = this.keyProp;
-		let current = this.tail;
-		let prev: Item<T> | undefined;
+
+		// prev is always a complete T, current might be tail only contain pointers
+		let prev: T | undefined;
+		let current: SkipItem<T> = this.tail;
 		for (let l = this.symbols.length - 1; l >= 0; l--) {
 			const symbol = this.symbols[l];
-			while ((prev = current[symbol] as Item<T>) && prev[keyProp] > indexValue)
+			while ((prev = current[symbol]) && (prev as any)[keyProp] > indexValue)
 				current = prev;
 		}
-		return current[this.symbols[0]]?.[keyProp] === indexValue
+		return (current[this.symbols[0]] as any)?.[keyProp] === indexValue
 			? current[this.symbols[0]]
 			: undefined;
 	}
@@ -125,10 +133,10 @@ export class ReverseSortedSet<T extends object> {
 	 */
 	*[Symbol.iterator](): IterableIterator<T> {
 		const symbol = this.symbols[0];
-		let node: Item<T> | undefined = this.tail[symbol] as Item<T>;
+		let node = this.tail[symbol];
 		while (node) {
 			yield node;
-			node = node[symbol] as Item<T> | undefined;
+			node = node[symbol];
 		}
 	}
 
@@ -140,7 +148,7 @@ export class ReverseSortedSet<T extends object> {
 	 * Time complexity: O(1)
 	 */
 	prev(item: T): T | undefined {
-		return (item as Item<T>)[this.symbols[0]];
+		return item[this.symbols[0]];
 	}
 
 	/**
@@ -154,16 +162,16 @@ export class ReverseSortedSet<T extends object> {
 	remove(item: T): boolean {
 		if (!(this.symbols[0] in item)) return false;
 		const keyProp = this.keyProp;
-		const prop = item[keyProp];
+		const prop = (item as any)[keyProp];
 
-		let prev: Item<T> | undefined;
-		let current: Item<T> = this.tail;
-
+		// prev is always a complete T, current might be tail only contain pointers
+		let prev: T | undefined;
+		let current: SkipItem<T> = this.tail;
 		for (let l = this.symbols.length - 1; l >= 0; l--) {
 			const symbol = this.symbols[l];
 			while (
-				(prev = current[symbol] as Item<T>) &&
-				prev[keyProp] >= prop &&
+				(prev = current[symbol]) &&
+				(prev as any)[keyProp] >= prop &&
 				prev !== item
 			)
 				current = prev;
@@ -183,15 +191,15 @@ export class ReverseSortedSet<T extends object> {
 	 */
 	clear(): void {
 		const symbol = this.symbols[0];
-		let current: Item<T> | undefined = this.tail;
+		let current = this.tail;
 		while (current) {
-			const prev = current[symbol] as Item<T> | undefined;
+			const prev = current[symbol];
 			for (const symbol of this.symbols) {
 				if (!(symbol in current)) break;
 				delete current[symbol];
 			}
 			current = prev;
 		}
-		this.tail = {} as Item<T>;
+		this.tail = {};
 	}
 }


### PR DESCRIPTION
This feels slightly cleaner -- to me at least.
- Removes the need for some casts and/or other `any` cases.
- Enforces correct comparison type into `.get()`

This does also enforce polluting the call sites with `[idx: symbol]: SelfType` for type T, but arguable that is what really happens. A little cleaner ould maybe be a dedicated helper type `export type ReverseSortedSetItem<T> = T & {[idx: symbol]: T}`.

PS: this project could use some linting rules with its mix of (trailing) spaces and tabs! :)