### PR TITLE
Allow ReadonlyArray in onEach

### DIFF
--- a/src/aberdeen.ts
+++ b/src/aberdeen.ts
@@ -823,7 +823,7 @@ function subscribe(
 }
 
 export function onEach<T>(
-	target: Array<undefined | T>,
+	target: ReadonlyArray<undefined | T>,
 	render: (value: T, index: number) => void,
 	makeKey?: (value: T, key: any) => SortKeyType,
 ): void;


### PR DESCRIPTION
It would be convenient if onEach supported ReadonlyArray the same as Array.

Currently if a ReadonlyArray is passed to onEach, the arguments of render are not correctly typed.